### PR TITLE
Feature - purge empty anon keys

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -49,7 +49,6 @@ slicebox {
 		config = ${slicebox.dicom-storage.file-system}
 	}
 
-
 	database {
 
 		// For H2 embedded
@@ -61,7 +60,11 @@ slicebox {
 		user = ""
 		password = ""
 	}
-	  
+
+  anonymization {
+    purge-empty-keys = false
+  }
+
 	superuser {
 		user = "admin"
 		password = "admin"

--- a/src/main/resources/slicebox.conf
+++ b/src/main/resources/slicebox.conf
@@ -20,43 +20,6 @@ slicebox {
 	host = "0.0.0.0"
 	port = 5000
 
-	session-timeout = 600s
-
-	ssl {
-		ssl-encryption = off
-
-		keystore {
-			path = "slicebox.jks"
-			password = "slicebox"
-		}
-	}
-
-	public {
-		host = ${slicebox.host}
-		port = ${slicebox.port}
-		with-ssl = false
-	}
-
-	dicom-storage {
-		file-system {
-			name = "on-disk"
-			path = "dicom"
-		}
-		s3 {
-			name = "s3"
-			# replace with S3 bucket name
-			bucket = "dicom-data.example.com"
-			# prefix for objects stored on S3
-			prefix = "dicom"
-		}
-		config = ${slicebox.dicom-storage.file-system}
-	}
-
-
-	database {
-		path = "jdbc:h2:./slicebox"
-	}
-	  
 	superuser {
 		user = "admin"
 		password = "admin"

--- a/src/main/scala/se/nimsa/sbx/anonymization/AnonymizationServiceActor.scala
+++ b/src/main/scala/se/nimsa/sbx/anonymization/AnonymizationServiceActor.scala
@@ -26,7 +26,7 @@ import se.nimsa.sbx.app.GeneralProtocol.ImageDeleted
 import se.nimsa.sbx.dicom.DicomUtil.{cloneAttributes, attributesToPatient}
 import se.nimsa.sbx.util.ExceptionCatching
 
-class AnonymizationServiceActor(dbProps: DbProps) extends Actor with ExceptionCatching {
+class AnonymizationServiceActor(dbProps: DbProps, purgeEmptyAnonymizationKeys: Boolean) extends Actor with ExceptionCatching {
 
   val log = Logging(context.system, this)
 
@@ -139,7 +139,7 @@ class AnonymizationServiceActor(dbProps: DbProps) extends Actor with ExceptionCa
 
   def removeImageFromAnonymizationKeyImages(imageId: Long) =
     db.withSession { implicit session =>
-      dao.removeAnonymizationKeyImagesForImageId(imageId)
+      dao.removeAnonymizationKeyImagesForImageId(imageId, purgeEmptyAnonymizationKeys)
     }
 
   def getAnonymizationKeyImagesByAnonymizationKeyId(anonymizationKeyId: Long) =
@@ -162,5 +162,5 @@ class AnonymizationServiceActor(dbProps: DbProps) extends Actor with ExceptionCa
 }
 
 object AnonymizationServiceActor {
-  def props(dbProps: DbProps): Props = Props(new AnonymizationServiceActor(dbProps))
+  def props(dbProps: DbProps, purgeEmptyAnonymizationKeys: Boolean): Props = Props(new AnonymizationServiceActor(dbProps, purgeEmptyAnonymizationKeys))
 }

--- a/src/main/scala/se/nimsa/sbx/app/SliceboxServiceActor.scala
+++ b/src/main/scala/se/nimsa/sbx/app/SliceboxServiceActor.scala
@@ -123,6 +123,8 @@ trait SliceboxService extends HttpService with SliceboxRoutes with JsonFormats {
 
   implicit val timeout = Timeout(math.max(clientTimeout, serverTimeout) + 10, MILLISECONDS)
 
+  val purgeEmptyAnonymizationKeys = sliceboxConfig.getBoolean("anonymization.purge-empty-keys")
+
   val apiBaseURL = {
 
     val ssl = if (withSsl) "s" else ""
@@ -147,7 +149,7 @@ trait SliceboxService extends HttpService with SliceboxRoutes with JsonFormats {
   val logService = actorRefFactory.actorOf(LogServiceActor.props(dbProps), name = "LogService")
   val metaDataService = actorRefFactory.actorOf(MetaDataServiceActor.props(dbProps).withDispatcher("akka.prio-dispatcher"), name = "MetaDataService")
   val storageService = actorRefFactory.actorOf(StorageServiceActor.props(storage), name = "StorageService")
-  val anonymizationService = actorRefFactory.actorOf(AnonymizationServiceActor.props(dbProps), name = "AnonymizationService")
+  val anonymizationService = actorRefFactory.actorOf(AnonymizationServiceActor.props(dbProps, purgeEmptyAnonymizationKeys), name = "AnonymizationService")
   val boxService = actorRefFactory.actorOf(BoxServiceActor.props(dbProps, apiBaseURL, timeout), name = "BoxService")
   val scpService = actorRefFactory.actorOf(ScpServiceActor.props(dbProps, timeout), name = "ScpService")
   val scuService = actorRefFactory.actorOf(ScuServiceActor.props(dbProps, timeout), name = "ScuService")

--- a/src/main/scala/se/nimsa/sbx/storage/StorageServiceActor.scala
+++ b/src/main/scala/se/nimsa/sbx/storage/StorageServiceActor.scala
@@ -20,7 +20,7 @@ import java.nio.file.NoSuchFileException
 
 import akka.actor.{Actor, Props}
 import akka.event.{Logging, LoggingReceive}
-import se.nimsa.sbx.app.GeneralProtocol.ImageAdded
+import se.nimsa.sbx.app.GeneralProtocol.{ImageAdded, ImageDeleted}
 import se.nimsa.sbx.dicom.{Contexts, DicomData, DicomUtil}
 import se.nimsa.sbx.storage.StorageProtocol._
 import se.nimsa.sbx.util.ExceptionCatching
@@ -71,7 +71,8 @@ class StorageServiceActor(storage: StorageService,
           val dicomDataDeleted = DicomDataDeleted(image)
           try {
             storage.deleteFromStorage(image)
-            context.system.eventStream.publish(dicomDataDeleted)
+            val imageDeleted = ImageDeleted(image.id)
+            context.system.eventStream.publish(imageDeleted)
           } catch {
             case e: NoSuchFileException => log.info(s"DICOM file for image with id ${image.id} could not be found, no need to delete.")
           }

--- a/src/test/scala/se/nimsa/sbx/anonymization/AnonymizationServiceActorTest.scala
+++ b/src/test/scala/se/nimsa/sbx/anonymization/AnonymizationServiceActorTest.scala
@@ -37,7 +37,7 @@ class AnonymizationServiceActorTest(_system: ActorSystem) extends TestKit(_syste
     anonymizationDao.create
   }
 
-  val anonymizationService = system.actorOf(Props(new AnonymizationServiceActor(dbProps)), name = "AnonymizationService")
+  val anonymizationService = system.actorOf(Props(new AnonymizationServiceActor(dbProps, purgeEmptyAnonymizationKeys = false)), name = "AnonymizationService")
 
   override def afterEach() =
     db.withSession { implicit session =>

--- a/src/test/scala/se/nimsa/sbx/box/BoxPollActorTest.scala
+++ b/src/test/scala/se/nimsa/sbx/box/BoxPollActorTest.scala
@@ -54,7 +54,7 @@ class BoxPollActorTest(_system: ActorSystem) extends TestKit(_system) with Impli
     }
   }), name = "MetaDataService")
   val storageService = system.actorOf(Props[MockupStorageActor], name = "StorageService")
-  val anonymizationService = system.actorOf(AnonymizationServiceActor.props(dbProps), name = "AnonymizationService")
+  val anonymizationService = system.actorOf(AnonymizationServiceActor.props(dbProps, purgeEmptyAnonymizationKeys = false), name = "AnonymizationService")
   val boxService = system.actorOf(BoxServiceActor.props(dbProps, "http://testhost:1234", 1.minute), name = "BoxService")
   val pollBoxActorRef = system.actorOf(Props(new BoxPollActor(remoteBox, 1.hour, 1000.hours, "../BoxService", "../MetaDataService", "../StorageService", "../AnonymizationService") {
 

--- a/src/test/scala/se/nimsa/sbx/box/BoxPushActorTest.scala
+++ b/src/test/scala/se/nimsa/sbx/box/BoxPushActorTest.scala
@@ -61,7 +61,7 @@ class BoxPushActorTest(_system: ActorSystem) extends TestKit(_system) with Impli
     }
   }), name = "MetaDataService")
   val storageService = system.actorOf(Props[MockupStorageActor], name = "StorageService")
-  val anonymizationService = system.actorOf(AnonymizationServiceActor.props(dbProps), name = "AnonymizationService")
+  val anonymizationService = system.actorOf(AnonymizationServiceActor.props(dbProps, purgeEmptyAnonymizationKeys = false), name = "AnonymizationService")
   val boxService = system.actorOf(BoxServiceActor.props(dbProps, "http://testhost:1234", 1.minute), name = "BoxService")
 
   var reportTransactionAsFailed = false


### PR DESCRIPTION
Using a new setting `anonymization.purge-empty-keys` (true/false) slicebox can now be set up to remove anonymization keys that no longer have images associated with them. That is, when image data is deleted from the system, unused anonymization keys will be purged.