### PR TITLE
#101 MySql problem with indexing unbounded columns

### DIFF
--- a/src/main/scala/se/nimsa/sbx/box/BoxDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/box/BoxDAO.scala
@@ -40,7 +40,7 @@ class BoxDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: ExecutionCont
 
   class BoxTable(tag: Tag) extends Table[Box](tag, BoxTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def name = column[String]("name")
+    def name = column[String]("name", O.Length(255))
     def token = column[String]("token")
     def baseUrl = column[String]("baseurl")
     def sendMethod = column[BoxSendMethod]("sendmethod")

--- a/src/main/scala/se/nimsa/sbx/forwarding/ForwardingDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/forwarding/ForwardingDAO.scala
@@ -35,10 +35,10 @@ class ForwardingDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Execut
 
   class ForwardingRuleTable(tag: Tag) extends Table[ForwardingRule](tag, ForwardingRuleTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def sourceType = column[String]("sourcetype")
+    def sourceType = column[String]("sourcetype", O.Length(255))
     def sourceName = column[String]("sourcename")
     def sourceId = column[Long]("sourceid")
-    def destinationType = column[String]("destinationtype")
+    def destinationType = column[String]("destinationtype", O.Length(255))
     def destinationName = column[String]("destinationname")
     def destinationId = column[Long]("destinationid")
     def keepImages = column[Boolean]("keepimages")

--- a/src/main/scala/se/nimsa/sbx/importing/ImportDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/importing/ImportDAO.scala
@@ -31,7 +31,7 @@ class ImportDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: ExecutionC
 
   class ImportSessionTable(tag: Tag) extends Table[ImportSession](tag, ImportSessionTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def name = column[String]("name")
+    def name = column[String]("name", O.Length(255))
     def userId = column[Long]("userid")
     def user = column[String]("user")
     def filesImported = column[Int]("filesimported")

--- a/src/main/scala/se/nimsa/sbx/metadata/MetaDataDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/metadata/MetaDataDAO.scala
@@ -44,8 +44,8 @@ class MetaDataDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Executio
 
   class PatientsTable(tag: Tag) extends Table[Patient](tag, PatientsTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def patientName = column[String](DicomProperty.PatientName.name)
-    def patientID = column[String](DicomProperty.PatientID.name)
+    def patientName = column[String](DicomProperty.PatientName.name, O.Length(255))
+    def patientID = column[String](DicomProperty.PatientID.name, O.Length(255))
     def patientBirthDate = column[String](DicomProperty.PatientBirthDate.name)
     def patientSex = column[String](DicomProperty.PatientSex.name)
     def idxUniquePatient = index("idx_unique_patient", (patientName, patientID), unique = true)
@@ -68,7 +68,7 @@ class MetaDataDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Executio
   class StudiesTable(tag: Tag) extends Table[Study](tag, StudiesTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def patientId = column[Long]("patientId")
-    def studyInstanceUID = column[String](DicomProperty.StudyInstanceUID.name)
+    def studyInstanceUID = column[String](DicomProperty.StudyInstanceUID.name, O.Length(255))
     def studyDescription = column[String](DicomProperty.StudyDescription.name)
     def studyDate = column[String](DicomProperty.StudyDate.name)
     def studyID = column[String](DicomProperty.StudyID.name)
@@ -96,7 +96,7 @@ class MetaDataDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Executio
   class SeriesTable(tag: Tag) extends Table[Series](tag, SeriesTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def studyId = column[Long]("studyId")
-    def seriesInstanceUID = column[String](DicomProperty.SeriesInstanceUID.name)
+    def seriesInstanceUID = column[String](DicomProperty.SeriesInstanceUID.name, O.Length(255))
     def seriesDescription = column[String](DicomProperty.SeriesDescription.name)
     def seriesDate = column[String](DicomProperty.SeriesDate.name)
     def modality = column[String](DicomProperty.Modality.name)
@@ -127,7 +127,7 @@ class MetaDataDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Executio
   class ImagesTable(tag: Tag) extends Table[Image](tag, ImagesTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def seriesId = column[Long]("seriesId")
-    def sopInstanceUID = column[String](DicomProperty.SOPInstanceUID.name)
+    def sopInstanceUID = column[String](DicomProperty.SOPInstanceUID.name, O.Length(255))
     def imageType = column[String](DicomProperty.ImageType.name)
     def instanceNumber = column[String](DicomProperty.InstanceNumber.name)
     def idxUniqueImage = index("idx_unique_image", (seriesId, sopInstanceUID), unique = true)

--- a/src/main/scala/se/nimsa/sbx/metadata/MetaDataDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/metadata/MetaDataDAO.scala
@@ -44,7 +44,7 @@ class MetaDataDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Executio
 
   class PatientsTable(tag: Tag) extends Table[Patient](tag, PatientsTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def patientName = column[String](DicomProperty.PatientName.name, O.Length(255))
+    def patientName = column[String](DicomProperty.PatientName.name, O.Length(512))
     def patientID = column[String](DicomProperty.PatientID.name, O.Length(255))
     def patientBirthDate = column[String](DicomProperty.PatientBirthDate.name)
     def patientSex = column[String](DicomProperty.PatientSex.name)

--- a/src/main/scala/se/nimsa/sbx/metadata/PropertiesDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/metadata/PropertiesDAO.scala
@@ -69,7 +69,7 @@ class PropertiesDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Execut
 
   class SeriesTagTable(tag: Tag) extends Table[SeriesTag](tag, SeriesTagTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def name = column[String]("name")
+    def name = column[String]("name", O.Length(255))
     def idxUniqueName = index("idx_unique_series_tag_name", name, unique = true)
     def * = (id, name) <> (toSeriesTag.tupled, fromSeriesTag)
   }

--- a/src/main/scala/se/nimsa/sbx/seriestype/SeriesTypeDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/seriestype/SeriesTypeDAO.scala
@@ -31,7 +31,7 @@ class SeriesTypeDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: Execut
 
   class SeriesTypeTable(tag: Tag) extends Table[SeriesType](tag, SeriesTypeTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def name = column[String]("name")
+    def name = column[String]("name", O.Length(255))
     def idxUniqueName = index("idx_unique_series_type_name", name, unique = true)
     def * = (id, name) <> (SeriesType.tupled, SeriesType.unapply)
   }

--- a/src/main/scala/se/nimsa/sbx/user/UserDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/user/UserDAO.scala
@@ -50,7 +50,7 @@ class UserDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: ExecutionCon
     def userId = column[Long]("userid")
     def token = column[String]("token", O.Length(255))
     def ip = column[String]("ip", O.Length(255))
-    def userAgent = column[String]("useragent", O.Length(255))
+    def userAgent = column[String]("useragent", O.Length(512))
     def updated = column[Long]("updated")
     def fkUser = foreignKey("fk_user", userId, users)(_.id, onDelete = ForeignKeyAction.Cascade)
     def idxUniqueSession = index("idx_unique_session", (token, ip, userAgent), unique = true)

--- a/src/main/scala/se/nimsa/sbx/user/UserDAO.scala
+++ b/src/main/scala/se/nimsa/sbx/user/UserDAO.scala
@@ -34,7 +34,7 @@ class UserDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: ExecutionCon
 
   class UserTable(tag: Tag) extends Table[ApiUser](tag, UserTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
-    def user = column[String]("user")
+    def user = column[String]("user", O.Length(255))
     def role = column[String]("role")
     def password = column[String]("password")
     def idxUniqueUser = index("idx_unique_user", user, unique = true)
@@ -48,9 +48,9 @@ class UserDAO(val dbConf: DatabaseConfig[JdbcProfile])(implicit ec: ExecutionCon
   class SessionTable(tag: Tag) extends Table[ApiSession](tag, SessionTable.name) {
     def id = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def userId = column[Long]("userid")
-    def token = column[String]("token")
-    def ip = column[String]("ip")
-    def userAgent = column[String]("useragent")
+    def token = column[String]("token", O.Length(255))
+    def ip = column[String]("ip", O.Length(255))
+    def userAgent = column[String]("useragent", O.Length(255))
     def updated = column[Long]("updated")
     def fkUser = foreignKey("fk_user", userId, users)(_.id, onDelete = ForeignKeyAction.Cascade)
     def idxUniqueSession = index("idx_unique_session", (token, ip, userAgent), unique = true)


### PR DESCRIPTION
MySql has problems with string columns that are unlimited in length if they are used as primary key or in a index. See #101. 