### PR TITLE
Updated readme to point to new API location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Travis            | [![Build Status](https://travis-ci.org/slicebox/slicebox.svg
 Coveralls         | [![Coverage Status](https://coveralls.io/repos/github/slicebox/slicebox/badge.svg?branch=develop)](https://coveralls.io/github/slicebox/slicebox?branch=develop) | Code coverage
 Gitter            | [![Join the chat at https://gitter.im/slicebox/slicebox](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/slicebox/slicebox?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) | Chatroom
 Documentation     | - | [Wiki](https://github.com/slicebox/slicebox/wiki)
-API Documentation | - | [REST API](http://slicebox.github.io/slicebox)
+API Documentation | - | [REST API](http://slicebox.github.io/slicebox-api)
 
 Slicebox is a microservice for safe sharing and easy access to medical images. The goal of the project is to facilitate research and collaboration between hospitals and universities. The service makes it easy to send images from the hosptial's PACS (image archive) to collaborators on the outside. Anonymization is handled automatically, releaving the hospital staff of the burden of making sure patient information does not leave the hospital network.
 


### PR DESCRIPTION
Moved API specification from orphan gh-pages branch in slicebox to its own repo slicebox/slicebox-api. This commit updates the link in the slicebox README.