### PR TITLE
Removed ‘version in Rpm’ use ‘version’ as default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,12 +41,10 @@ bashScriptExtraDefines ++= Seq(
   """addJava "-Dlogback.configurationFile=${app_home}/../conf/logback.xml" """)
 
 // rpm specific
-
 rpmVendor := maintainer.value
 rpmLicense := Some("Apache v2")
 packageArchitecture in Rpm := "noarch"
 rpmGroup := Some("Applications/Research")
-version in Rpm := version.value.replace("-SNAPSHOT", "")
 rpmRelease := {
   if (version.value.matches(".*-SNAPSHOT")) System.currentTimeMillis().toString else "1"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ rpmVendor := maintainer.value
 rpmLicense := Some("Apache v2")
 packageArchitecture in Rpm := "noarch"
 rpmGroup := Some("Applications/Research")
+version in Rpm := version.value.replace("-SNAPSHOT", "")
 rpmRelease := {
   if (version.value.matches(".*-SNAPSHOT")) System.currentTimeMillis().toString else "1"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-jshint" % "1.0.4")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "2.0.0")
 


### PR DESCRIPTION
fixes #165 