### PR TITLE
Update to dcm4che-streams 0.5-SNAPSHOT. Removed reference to Slicebox…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ libraryDependencies ++= {
     "org.webjars" % "angularjs" % "1.5.9",
     "org.webjars" % "angular-material" % "1.1.4",
     "org.webjars" % "angular-file-upload" % "11.0.0",
-    "se.nimsa" %% "dcm4che-streams" % "0.4" exclude("org.slf4j", "slf4j-simple"),
+    "se.nimsa" %% "dcm4che-streams" % "0.5-SNAPSHOT" exclude("org.slf4j", "slf4j-simple"),
     "com.lightbend.akka" %% "akka-stream-alpakka-s3" % alpakkaVersion,
     "com.lightbend.akka" %% "akka-stream-alpakka-file" % alpakkaVersion
   )

--- a/src/main/scala/se/nimsa/sbx/app/routing/AnonymizationRoutes.scala
+++ b/src/main/scala/se/nimsa/sbx/app/routing/AnonymizationRoutes.scala
@@ -27,6 +27,7 @@ import se.nimsa.sbx.app.SliceboxBase
 import se.nimsa.sbx.dicom.DicomHierarchy.Image
 import se.nimsa.sbx.metadata.MetaDataProtocol._
 import se.nimsa.sbx.user.UserProtocol.ApiUser
+import se.nimsa.sbx.util.FutureUtil
 
 import scala.concurrent.Future
 
@@ -59,9 +60,8 @@ trait AnonymizationRoutes {
         post {
           entity(as[Seq[ImageTagValues]]) { imageTagValuesSeq =>
             complete {
-              Future.sequence {
-                imageTagValuesSeq.map(imageTagValues =>
-                  anonymizeData(imageTagValues.imageId, imageTagValues.tagValues, storage))
+              FutureUtil.traverseSequentially(imageTagValuesSeq) { imageTagValues =>
+                anonymizeData(imageTagValues.imageId, imageTagValues.tagValues, storage)
               }.map(_.flatMap(_.map(_.image)))
             }
           }

--- a/src/main/scala/se/nimsa/sbx/app/routing/ImageRoutes.scala
+++ b/src/main/scala/se/nimsa/sbx/app/routing/ImageRoutes.scala
@@ -20,7 +20,7 @@ import java.io.ByteArrayOutputStream
 import java.util.zip.{ZipEntry, ZipOutputStream}
 
 import akka.NotUsed
-import akka.http.scaladsl.common.EntityStreamingSupport
+import akka.http.scaladsl.common.{EntityStreamingSupport, JsonEntityStreamingSupport}
 import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.model.MediaTypes._
 import akka.http.scaladsl.model.StatusCodes._
@@ -32,6 +32,7 @@ import akka.stream.scaladsl.{Sink, SourceQueueWithComplete, Source => StreamSour
 import akka.stream.{OverflowStrategy, QueueOfferResult}
 import akka.util.ByteString
 import se.nimsa.dcm4che.streams.DicomModifyFlow.TagModification
+import se.nimsa.dcm4che.streams.padToEvenLength
 import se.nimsa.sbx.app.GeneralProtocol._
 import se.nimsa.sbx.app.SliceboxBase
 import se.nimsa.sbx.dicom.DicomHierarchy.{FlatSeries, Image, Patient, Study}
@@ -48,7 +49,7 @@ import scala.util.{Failure, Success}
 trait ImageRoutes {
   this: SliceboxBase =>
 
-  implicit val jsonStreamingSupport = EntityStreamingSupport.json()
+  implicit val jsonStreamingSupport: JsonEntityStreamingSupport = EntityStreamingSupport.json()
 
   def imageRoutes(apiUser: ApiUser): Route =
     pathPrefix("images") {
@@ -86,7 +87,8 @@ trait ImageRoutes {
             'windowmax.as[Int] ? 0,
             'imageheight.as[Int] ? 0)) { (frameNumber, min, max, height) =>
             get {
-              onComplete(storage.readPngImageData(imageId, frameNumber, min, max, height)) {
+              // use dedicated thread pool for blocking IO here
+              onComplete(storage.readPngImageData(imageId, frameNumber, min, max, height)(materializer, blockingIoContext)) {
                 case Success(bytes) => complete(HttpEntity(`image/png`, bytes))
                 case Failure(_: NotFoundException) => complete(NotFound)
                 case Failure(_) => complete(NotImplemented)
@@ -97,7 +99,7 @@ trait ImageRoutes {
           put {
             entity(as[Seq[TagMapping]]) { tagMappings =>
               val tagModifications = tagMappings
-                .map(tm => TagModification(tm.tagPath, _ => DicomUtil.padToEvenLength(tm.value, tm.tagPath.tag), insert = true))
+                .map(tm => TagModification(tm.tagPath, _ => padToEvenLength(tm.value, tm.tagPath.tag), insert = true))
               onSuccess(modifyData(imageId, tagModifications, storage)) {
                 case (metaDataDeleted, metaDataAdded) =>
                   system.eventStream.publish(ImagesDeleted(metaDataDeleted.imageIds))

--- a/src/main/scala/se/nimsa/sbx/app/routing/ImageRoutes.scala
+++ b/src/main/scala/se/nimsa/sbx/app/routing/ImageRoutes.scala
@@ -180,7 +180,8 @@ trait ImageRoutes {
     val futureUpload = storeDicomData(bytes, source, storage, Contexts.extendedContexts)
 
     onSuccess(futureUpload) { metaData =>
-      system.eventStream.publish(ImageAdded(metaData.image.id, source, !metaData.imageAdded))
+      val overwrite = !metaData.imageAdded
+      system.eventStream.publish(ImageAdded(metaData.image.id, source, overwrite))
       val httpStatus = if (metaData.imageAdded) Created else OK
       complete((httpStatus, metaData.image))
     }

--- a/src/main/scala/se/nimsa/sbx/app/routing/ImageRoutes.scala
+++ b/src/main/scala/se/nimsa/sbx/app/routing/ImageRoutes.scala
@@ -99,7 +99,7 @@ trait ImageRoutes {
           put {
             entity(as[Seq[TagMapping]]) { tagMappings =>
               val tagModifications = tagMappings
-                .map(tm => TagModification(tm.tagPath, _ => padToEvenLength(tm.value, tm.tagPath.tag), insert = true))
+                .map(tm => TagModification.contains(tm.tagPath, _ => padToEvenLength(tm.value, tm.tagPath.tag), insert = true))
               onSuccess(modifyData(imageId, tagModifications, storage)) {
                 case (metaDataDeleted, metaDataAdded) =>
                   system.eventStream.publish(ImagesDeleted(metaDataDeleted.imageIds))

--- a/src/main/scala/se/nimsa/sbx/app/routing/ImportRoutes.scala
+++ b/src/main/scala/se/nimsa/sbx/app/routing/ImportRoutes.scala
@@ -107,7 +107,8 @@ trait ImportRoutes {
         onComplete(futureImport) {
           case Success(metaData) =>
             onSuccess(importService.ask(AddImageToSession(importSession.id, metaData.image, !metaData.imageAdded)).mapTo[ImageAddedToSession]) { _ =>
-              system.eventStream.publish(ImageAdded(metaData.image.id, source, !metaData.imageAdded))
+              val overwrite = !metaData.imageAdded
+              system.eventStream.publish(ImageAdded(metaData.image.id, source, overwrite))
               val httpStatus = if (metaData.imageAdded) Created else OK
               complete((httpStatus, metaData.image))
             }

--- a/src/main/scala/se/nimsa/sbx/app/routing/TransactionRoutes.scala
+++ b/src/main/scala/se/nimsa/sbx/app/routing/TransactionRoutes.scala
@@ -46,7 +46,8 @@ trait TransactionRoutes {
                   val source = Source(SourceType.BOX, box.name, box.id)
                   onSuccess(storeDicomData(compressedBytes.via(Compression.inflate()), source, storage, Contexts.extendedContexts)) { metaData =>
                     system.eventStream.publish(ImageAdded(metaData.image.id, source, !metaData.imageAdded))
-                    onSuccess(boxService.ask(UpdateIncoming(box, outgoingTransactionId, sequenceNumber, totalImageCount, metaData.image.id, metaData.imageAdded))) {
+                    val overwrite = !metaData.imageAdded
+                    onSuccess(boxService.ask(UpdateIncoming(box, outgoingTransactionId, sequenceNumber, totalImageCount, metaData.image.id, overwrite))) {
                       case IncomingUpdated(transaction) =>
                         transaction.status match {
                           case TransactionStatus.FAILED => complete(InternalServerError)

--- a/src/main/scala/se/nimsa/sbx/dicom/DicomUtil.scala
+++ b/src/main/scala/se/nimsa/sbx/dicom/DicomUtil.scala
@@ -16,14 +16,13 @@
 
 package se.nimsa.sbx.dicom
 
-import akka.util.ByteString
 import org.dcm4che3.data._
 import se.nimsa.sbx.dicom.DicomHierarchy._
 import se.nimsa.sbx.dicom.DicomPropertyValue._
 
 object DicomUtil {
 
-  def isAnonymous(attributes: Attributes) = attributes.getString(Tag.PatientIdentityRemoved, "NO") == "YES"
+  def isAnonymous(attributes: Attributes): Boolean = attributes.getString(Tag.PatientIdentityRemoved, "NO") == "YES"
 
   def cloneAttributes(attributes: Attributes): Attributes = new Attributes(attributes)
 
@@ -76,26 +75,19 @@ object DicomUtil {
     else
       values.tail.foldLeft(values.head)((result, part) => result + "/" + part)
 
-  def getStrings(attrs: Attributes, tag: Int) = {
+  def getStrings(attrs: Attributes, tag: Int): Array[String] = {
     val s = attrs.getStrings(tag)
     if (s == null || s.isEmpty) Array("") else s
   }
 
-  def concatenatedStringForTag(attrs: Attributes, tag: Int) = {
+  def concatenatedStringForTag(attrs: Attributes, tag: Int): String = {
     val array = getStrings(attrs, tag)
     array.mkString(",")
   }
 
-  def nameForTag(tag: Int) = {
+  def nameForTag(tag: Int): String = {
     val name = Keyword.valueOf(tag)
     if (name == null) "" else name
-  }
-
-  def padToEvenLength(bytes: ByteString, tag: Int): ByteString = padToEvenLength(bytes, StandardElementDictionary.INSTANCE.vrOf(tag))
-
-  def padToEvenLength(bytes: ByteString, vr: VR): ByteString = {
-    val padding = if ((bytes.length & 1) != 0) ByteString(vr.paddingByte()) else ByteString.empty
-    bytes ++ padding
   }
 
 }

--- a/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationFlow.scala
+++ b/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationFlow.scala
@@ -17,9 +17,9 @@ import scala.util.Random
 object AnonymizationFlow {
 
   private def toAsciiBytes(s: String, vr: VR) = padToEvenLength(ByteString(s), vr)
-  private def insert(tag: Int, mod: ByteString => ByteString) = TagModification(TagPath.fromTag(tag), mod, insert = true)
-  private def modify(tag: Int, mod: ByteString => ByteString) = TagModification(TagPath.fromTag(tag), mod, insert = false)
-  private def clear(tag: Int) = TagModification(TagPath.fromTag(tag), _ => ByteString.empty, insert = false)
+  private def insert(tag: Int, mod: ByteString => ByteString) = TagModification.endsWith(TagPath.fromTag(tag), mod, insert = true)
+  private def modify(tag: Int, mod: ByteString => ByteString) = TagModification.endsWith(TagPath.fromTag(tag), mod, insert = false)
+  private def clear(tag: Int) = TagModification.endsWith(TagPath.fromTag(tag), _ => ByteString.empty, insert = false)
   private def createAccessionNumber(accessionNumberBytes: ByteString): ByteString = {
     val seed = UUID.nameUUIDFromBytes(accessionNumberBytes.toArray).getMostSignificantBits
     val rand = new Random(seed)

--- a/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationFlow.scala
+++ b/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationFlow.scala
@@ -2,20 +2,21 @@ package se.nimsa.sbx.dicom.streams
 
 import java.util.UUID
 
+import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import org.dcm4che3.data.{Tag, VR}
 import org.dcm4che3.util.UIDUtils
-import se.nimsa.dcm4che.streams.DicomModifyFlow.TagModification
+import se.nimsa.dcm4che.streams.DicomFlows._
+import se.nimsa.dcm4che.streams.DicomModifyFlow._
 import se.nimsa.dcm4che.streams.DicomParts._
-import se.nimsa.dcm4che.streams.{DicomFlows, DicomModifyFlow, DicomParsing, TagPath}
-import se.nimsa.sbx.dicom.DicomUtil
+import se.nimsa.dcm4che.streams._
 
 import scala.util.Random
 
 object AnonymizationFlow {
 
-  private def toAsciiBytes(s: String, vr: VR) = DicomUtil.padToEvenLength(ByteString(s), vr)
+  private def toAsciiBytes(s: String, vr: VR) = padToEvenLength(ByteString(s), vr)
   private def insert(tag: Int, mod: ByteString => ByteString) = TagModification(TagPath.fromTag(tag), mod, insert = true)
   private def modify(tag: Int, mod: ByteString => ByteString) = TagModification(TagPath.fromTag(tag), mod, insert = false)
   private def clear(tag: Int) = TagModification(TagPath.fromTag(tag), _ => ByteString.empty, insert = false)
@@ -31,7 +32,7 @@ object AnonymizationFlow {
     else
       UIDUtils.createNameBasedUID(baseValue.toArray), VR.UI)
   private def isOverlay(tag: Int): Boolean = {
-    val group = DicomParsing.groupNumber(tag)
+    val group = groupNumber(tag)
     group >= 0x6000 && group < 0x6100
   }
 
@@ -208,11 +209,11 @@ object AnonymizationFlow {
     * Remove overlay data
     * Remove, set empty or modify certain attributes
     */
-  val anonFlow = Flow[DicomPart]
-    .via(DicomFlows.blacklistFilter(DicomParsing.isPrivateAttribute _)) // remove private attributes
-    .via(DicomFlows.blacklistFilter(isOverlay _)) // remove overlay data
-    .via(DicomFlows.blacklistFilter(removeTags.contains _)) // remove tags from above list, if present
-    .via(DicomModifyFlow.modifyFlow( // modify, clear and insert
+  val anonFlow: Flow[DicomPart, DicomPart, NotUsed] = Flow[DicomPart]
+    .via(blacklistFilter(DicomParsing.isPrivateAttribute _)) // remove private attributes
+    .via(blacklistFilter(isOverlay _)) // remove overlay data
+    .via(blacklistFilter(removeTags.contains _)) // remove tags from above list, if present
+    .via(modifyFlow( // modify, clear and insert
     modify(Tag.AccessionNumber, bytes => if (bytes.nonEmpty) createAccessionNumber(bytes) else bytes),
     modify(Tag.ConcatenationUID, createUid),
     clear(Tag.ContentCreatorName),
@@ -255,8 +256,7 @@ object AnonymizationFlow {
     modify(Tag.TemplateExtensionOrganizationUID, createUid),
     modify(Tag.TransactionUID, createUid),
     modify(Tag.UID, createUid),
-    clear(Tag.VerifyingObserverName)
-  ))
+    clear(Tag.VerifyingObserverName)))
 
   /**
     * Anonymize data if not already anonymized. Assumes first `DicomPart` is a `DicomMetaPart` that is used to determine
@@ -264,7 +264,7 @@ object AnonymizationFlow {
     *
     * @return a `Flow` of `DicomParts` that will anonymize non-anonymized data but does nothing otherwise
     */
-  val maybeAnonFlow = DicomStreamOps.conditionalFlow(
+  val maybeAnonFlow: Flow[DicomPart, DicomPart, NotUsed] = DicomStreamOps.conditionalFlow(
     {
       case p: DicomMetaPart => !p.isAnonymized
     }, anonFlow, Flow.fromFunction(identity))

--- a/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationKeysPart.scala
+++ b/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationKeysPart.scala
@@ -5,7 +5,7 @@ import se.nimsa.dcm4che.streams.DicomParts._
 import se.nimsa.sbx.anonymization.AnonymizationProtocol.AnonymizationKey
 
 
-case class AnonymizationKeysPart(allKeys: Seq[AnonymizationKey],
+case class AnonymizationKeysPart(patientKeys: Seq[AnonymizationKey],
                                  patientKey: Option[AnonymizationKey],
                                  studyKey: Option[AnonymizationKey],
                                  seriesKey: Option[AnonymizationKey]) extends DicomPart {

--- a/src/main/scala/se/nimsa/sbx/dicom/streams/ReverseAnonymizationFlow.scala
+++ b/src/main/scala/se/nimsa/sbx/dicom/streams/ReverseAnonymizationFlow.scala
@@ -29,7 +29,7 @@ object ReverseAnonymizationFlow {
 
   val reverseAnonFlow = Flow[DicomPart]
     .via(DicomModifyFlow.modifyFlow(
-      reverseTags.map(tag => TagModification(TagPath.fromTag(tag), identity, insert = true)): _*))
+      reverseTags.map(tag => TagModification.endsWith(TagPath.fromTag(tag), identity, insert = true)): _*))
     .statefulMapConcat {
 
       () =>

--- a/src/test/scala/se/nimsa/sbx/app/routing/ImageRoutesTest.scala
+++ b/src/test/scala/se/nimsa/sbx/app/routing/ImageRoutesTest.scala
@@ -363,7 +363,7 @@ class ImageRoutesTest extends {
         .fromTag(Tag.RescaleSlope), ByteString("2.5")), // insert new attribute
       TagMapping(TagPath
         .fromSequence(Tag.EnergyWindowInformationSequence)
-        .thenSequence(Tag.EnergyWindowRangeSequence, 1)
+        .thenSequence(Tag.EnergyWindowRangeSequence, 2)
         .thenTag(Tag.EnergyWindowUpperLimit), ByteString("999")) // modify item in sequence
     )
 

--- a/src/test/scala/se/nimsa/sbx/dicom/streams/DicomStreamOpsTest.scala
+++ b/src/test/scala/se/nimsa/sbx/dicom/streams/DicomStreamOpsTest.scala
@@ -214,11 +214,11 @@ class DicomStreamOpsTest extends TestKit(ActorSystem("AnonymizationFlowSpec")) w
         .via(DicomPartFlow.partFlow)
         .via(DicomFlows.blacklistFilter(Seq(Tag.PixelData)))
         .via(DicomModifyFlow.modifyFlow(
-          TagModification(
+          TagModification.contains(
             TagPath.fromTag(Tag.MediaStorageSOPInstanceUID),
             uid => uid.dropRight(3) ++ ByteString(f"$sopInstanceUID%03d"),
             insert = true),
-          TagModification(
+          TagModification.contains(
             TagPath.fromTag(Tag.SOPInstanceUID),
             uid => uid.dropRight(3) ++ ByteString(f"$sopInstanceUID%03d"),
             insert = true)))
@@ -397,7 +397,7 @@ class DicomStreamOpsTest extends TestKit(ActorSystem("AnonymizationFlowSpec")) w
     val bytesSource = StreamSource.single(ByteString.fromArray(TestUtil.toByteArray(testData)))
     for {
       metaDataAdded1 <- dicomStreamOpsImpl.storeDicomData(bytesSource, source, storage, Contexts.imageDataContexts)
-      (_, metaDataAdded2) <- dicomStreamOpsImpl.modifyData(metaDataAdded1.image.id, Seq(TagModification(TagPath.fromTag(Tag.PatientName), _ => ByteString(newName), insert = true)), storage)
+      (_, metaDataAdded2) <- dicomStreamOpsImpl.modifyData(metaDataAdded1.image.id, Seq(TagModification.endsWith(TagPath.fromTag(Tag.PatientName), _ => ByteString(newName), insert = true)), storage)
     } yield {
       metaDataAdded2.patient.patientName.value shouldBe newName
     }

--- a/src/test/scala/se/nimsa/sbx/dicom/streams/DicomTestData.scala
+++ b/src/test/scala/se/nimsa/sbx/dicom/streams/DicomTestData.scala
@@ -2,28 +2,27 @@ package se.nimsa.sbx.dicom.streams
 
 import akka.util.ByteString
 import org.dcm4che3.data.{Attributes, Tag, UID, VR}
-import se.nimsa.dcm4che.streams.DicomParsing
-import se.nimsa.sbx.dicom.DicomUtil
+import se.nimsa.dcm4che.streams._
 
 object DicomTestData {
 
-  val preamble = ByteString.fromArray(new Array[Byte](128)) ++ ByteString('D', 'I', 'C', 'M')
-  def fmiGroupLength(fmis: ByteString*) = ByteString(2, 0, 0, 0, 85, 76, 4, 0) ++ DicomParsing.intToBytesLE(fmis.map(_.length).sum)
-  val tsuidExplicitLE = ByteString(2, 0, 16, 0, 85, 73, 20, 0, '1', '.', '2', '.', '8', '4', '0', '.', '1', '0', '0', '0', '8', '.', '1', '.', '2', '.', '1', 0)
-  val supportedMediaStorageSOPClassUID = ByteString(2, 0, 2, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.20".toCharArray.map(_.toByte))
-  val unsupportedMediaStorageSOPClassUID = ByteString(2, 0, 2, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.7".toCharArray.map(_.toByte)) ++ ByteString(0)
-  val unknownMediaStorageSOPClassUID = ByteString(2, 0, 2, 0, 85, 73, 8, 0) ++ ByteString.fromArray("1.2.3.4".toCharArray.map(_.toByte)) ++ ByteString(0)
-  val patientNameJohnDoe = ByteString(16, 0, 16, 0, 80, 78, 8, 0, 'J', 'o', 'h', 'n', '^', 'D', 'o', 'e')
-  val supportedSOPClassUID = ByteString(8, 0, 22, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.20".toCharArray.map(_.toByte))
-  val unsupportedSOPClassUID = ByteString(8, 0, 22, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.7".toCharArray.map(_.toByte)) ++ ByteString(0)
+  val preamble: ByteString = ByteString.fromArray(new Array[Byte](128)) ++ ByteString('D', 'I', 'C', 'M')
+  def fmiGroupLength(fmis: ByteString*): ByteString = ByteString(2, 0, 0, 0, 85, 76, 4, 0) ++ intToBytesLE(fmis.map(_.length).sum)
+  val tsuidExplicitLE: ByteString = ByteString(2, 0, 16, 0, 85, 73, 20, 0, '1', '.', '2', '.', '8', '4', '0', '.', '1', '0', '0', '0', '8', '.', '1', '.', '2', '.', '1', 0)
+  val supportedMediaStorageSOPClassUID: ByteString = ByteString(2, 0, 2, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.20".toCharArray.map(_.toByte))
+  val unsupportedMediaStorageSOPClassUID: ByteString = ByteString(2, 0, 2, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.7".toCharArray.map(_.toByte)) ++ ByteString(0)
+  val unknownMediaStorageSOPClassUID: ByteString = ByteString(2, 0, 2, 0, 85, 73, 8, 0) ++ ByteString.fromArray("1.2.3.4".toCharArray.map(_.toByte)) ++ ByteString(0)
+  val patientNameJohnDoe: ByteString = ByteString(16, 0, 16, 0, 80, 78, 8, 0, 'J', 'o', 'h', 'n', '^', 'D', 'o', 'e')
+  val supportedSOPClassUID: ByteString = ByteString(8, 0, 22, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.20".toCharArray.map(_.toByte))
+  val unsupportedSOPClassUID: ByteString = ByteString(8, 0, 22, 0, 85, 73, 26, 0) ++ ByteString.fromArray("1.2.840.10008.5.1.4.1.1.7".toCharArray.map(_.toByte)) ++ ByteString(0)
 
-  val metaInformation = {
+  val metaInformation: Attributes = {
     val meta = new Attributes()
     meta.setString(Tag.TransferSyntaxUID, VR.UI, UID.ExplicitVRLittleEndian)
     meta
   }
 
-  def createAttributes = {
+  def createAttributes: Attributes = {
     val attributes = new Attributes()
     attributes.setString(Tag.PatientName, VR.PN, "pn")
     attributes.setString(Tag.PatientID, VR.LO, "pid")
@@ -35,6 +34,6 @@ object DicomTestData {
     attributes
   }
 
-  def toAsciiBytes(s: String, vr: VR) = DicomUtil.padToEvenLength(ByteString(s), vr)
+  def toAsciiBytes(s: String, vr: VR): ByteString = padToEvenLength(ByteString(s), vr)
 
 }

--- a/src/test/scala/se/nimsa/sbx/dicom/streams/ReverseAnonymizationFlowTest.scala
+++ b/src/test/scala/se/nimsa/sbx/dicom/streams/ReverseAnonymizationFlowTest.scala
@@ -45,11 +45,11 @@ class ReverseAnonymizationFlowTest extends TestKit(ActorSystem("ReverseAnonymiza
     attributesSource(dicomData)
       .via(AnonymizationFlow.anonFlow)
       .via(DicomModifyFlow.modifyFlow(
-        TagModification(TagPath.fromTag(Tag.PatientName), _ => toAsciiBytes(key.anonPatientName, VR.PN), insert = false),
-        TagModification(TagPath.fromTag(Tag.PatientID), _ => toAsciiBytes(key.anonPatientID, VR.LO), insert = false),
-        TagModification(TagPath.fromTag(Tag.StudyInstanceUID), _ => toAsciiBytes(key.anonStudyInstanceUID, VR.UI), insert = false),
-        TagModification(TagPath.fromTag(Tag.SeriesInstanceUID), _ => toAsciiBytes(key.anonSeriesInstanceUID, VR.UI), insert = false),
-        TagModification(TagPath.fromTag(Tag.FrameOfReferenceUID), _ => toAsciiBytes(key.anonFrameOfReferenceUID, VR.UI), insert = false)
+        TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => toAsciiBytes(key.anonPatientName, VR.PN), insert = false),
+        TagModification.contains(TagPath.fromTag(Tag.PatientID), _ => toAsciiBytes(key.anonPatientID, VR.LO), insert = false),
+        TagModification.contains(TagPath.fromTag(Tag.StudyInstanceUID), _ => toAsciiBytes(key.anonStudyInstanceUID, VR.UI), insert = false),
+        TagModification.contains(TagPath.fromTag(Tag.SeriesInstanceUID), _ => toAsciiBytes(key.anonSeriesInstanceUID, VR.UI), insert = false),
+        TagModification.contains(TagPath.fromTag(Tag.FrameOfReferenceUID), _ => toAsciiBytes(key.anonFrameOfReferenceUID, VR.UI), insert = false)
       ))
   }
 

--- a/src/test/scala/se/nimsa/sbx/util/TestUtil.scala
+++ b/src/test/scala/se/nimsa/sbx/util/TestUtil.scala
@@ -226,7 +226,7 @@ object TestUtil {
 
     val metaInformation = new Attributes()
     metaInformation.setString(Tag.MediaStorageSOPClassUID, VR.UI, "1.2.840.10008.5.1.4.1.1.2")
-    metaInformation.setString(Tag.TransferSyntaxUID, VR.UI, "1.2.840.10008.5.1.4.1.1.2")
+    metaInformation.setString(Tag.TransferSyntaxUID, VR.UI, "1.2.840.10008.1.2.1")
 
     DicomData(attributes, metaInformation)
   }
@@ -240,15 +240,15 @@ object TestUtil {
     AnonymizationKey(-1, new Date().getTime,
       attributes.getString(Tag.PatientName), anonPatientName,
       attributes.getString(Tag.PatientID), anonPatientID,
-      attributes.getString(Tag.PatientBirthDate),
+      attributes.getString(Tag.PatientBirthDate, "1900-01-01"),
       attributes.getString(Tag.StudyInstanceUID), anonStudyInstanceUID,
       attributes.getString(Tag.StudyDescription),
-      attributes.getString(Tag.StudyID),
-      attributes.getString(Tag.AccessionNumber),
+      attributes.getString(Tag.StudyID, "Study ID"),
+      attributes.getString(Tag.AccessionNumber, "12345"),
       attributes.getString(Tag.SeriesInstanceUID), anonSeriesInstanceUID,
-      attributes.getString(Tag.SeriesDescription),
-      attributes.getString(Tag.ProtocolName),
-      attributes.getString(Tag.FrameOfReferenceUID), anonFrameOfReferenceUID)
+      attributes.getString(Tag.SeriesDescription, "Series Description"),
+      attributes.getString(Tag.ProtocolName, "Protocol Name"),
+      attributes.getString(Tag.FrameOfReferenceUID, "1.2.3.4.5"), anonFrameOfReferenceUID)
 
   def deleteFolderContents(path: Path) =
     Files.list(path).collect(Collectors.toList()).asScala.foreach { path =>


### PR DESCRIPTION
… object which should only be used as app entry point (was messing with tests). Made sure group lenth tags are either removed or updated when modifying dicom flows. Updated to stricter Scala coding conventions in IntelliJ in some places. Fixed bug where .mapAsync was used instead of .mapMaterializedValue in a DICOM flow which lead to one database hit per data chunk instead of one for the entire flow. Added tests for harmonization when anonymizing data.