### PR TITLE
Bugfix/s3 upload with retry

### DIFF
--- a/src/main/assets/js/directives.js
+++ b/src/main/assets/js/directives.js
@@ -158,9 +158,7 @@ angular.module('slicebox.directives', [])
                 }
             });
 
-            if (!$scope.objectList) {
-                loadPageData();
-            }
+            loadPageData();
 
             // Scope functions
             $scope.tableBodyStyle = function() {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -183,6 +183,7 @@ akka {
     }
     parsing {
       max-content-length = 500m
+      max-chunk-size = ${slicebox.stream.chunk-size}
     }
     host-connection-pool {
       max-retries = 0

--- a/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationFlow.scala
+++ b/src/main/scala/se/nimsa/sbx/dicom/streams/AnonymizationFlow.scala
@@ -210,9 +210,7 @@ object AnonymizationFlow {
     * Remove overlay data
     * Remove, set empty or modify certain attributes
     */
-  def anonFlow: Flow[DicomPart, DicomPart, NotUsed] = {
-    val sopInstanceUID = createUid(ByteString.empty)
-
+  def anonFlow: Flow[DicomPart, DicomPart, NotUsed] =
     Flow[DicomPart]
       .via(groupLengthDiscardFilter)
       .via(toUndefinedLengthSequences)
@@ -235,7 +233,7 @@ object AnonymizationFlow {
       modify(Tag.InstanceCreatorUID, createUid),
       modify(Tag.IrradiationEventUID, createUid),
       modify(Tag.LargePaletteColorLookupTableUID, createUid),
-      modify(Tag.MediaStorageSOPInstanceUID, _ => sopInstanceUID),
+      modify(Tag.MediaStorageSOPInstanceUID, createUid),
       modify(Tag.ObservationSubjectUIDTrial, createUid),
       modify(Tag.ObservationUID, createUid),
       modify(Tag.PaletteColorLookupTableUID, createUid),
@@ -252,7 +250,7 @@ object AnonymizationFlow {
       modify(Tag.RelatedFrameOfReferenceUID, createUid),
       modify(Tag.RequestedSOPInstanceUID, createUid),
       insert(Tag.SeriesInstanceUID, _ => createUid(null)),
-      insert(Tag.SOPInstanceUID, _ => sopInstanceUID),
+      insert(Tag.SOPInstanceUID, createUid),
       modify(Tag.StorageMediaFileSetUID, createUid),
       clear(Tag.StudyID),
       insert(Tag.StudyInstanceUID, _ => createUid(null)),
@@ -263,7 +261,6 @@ object AnonymizationFlow {
       modify(Tag.TransactionUID, createUid),
       modify(Tag.UID, createUid),
       clear(Tag.VerifyingObserverName)))
-  }
 
   /**
     * Anonymize data if not already anonymized. Assumes first `DicomPart` is a `PartialAnonymizationKeyPart` that is


### PR DESCRIPTION
This PR targets the problem with failing S3 calls and the lack of retry. The following observations have been made.

1. The upcoming AWS Java API for S3 supports async, streaming and seems to implement retry as in the current API: https://github.com/aws/aws-sdk-java-v2/search?utf8=%E2%9C%93&q=retry
2. Alpakka will use this new API when it becomes available: https://github.com/akka/alpakka/issues/372

It therefore does not make sense to implement retry across our entire code base. This PR provides a temporary solution where data is buffered completely in memory before being uploaded with the AWS S3 API which implements retry. The downside of this is of course that we no longer stream end-to-end and have less control over resources. In reality, this has limited impact since the current Alpakka code buffers 5Mb chunks before sending and most DICOM files are smaller than that. 