### PR TITLE
Delete on directory watch configurable

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,7 +20,7 @@ slicebox {
     with-ssl = false
   }
 
-  directory {
+  directory-watch {
     delete-on-import = false
   }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,6 +20,10 @@ slicebox {
     with-ssl = false
   }
 
+  directory {
+    delete-on-import = false
+  }
+
   dicom-storage {
     file-system {
       name = "on-disk"

--- a/src/main/scala/se/nimsa/sbx/app/Slicebox.scala
+++ b/src/main/scala/se/nimsa/sbx/app/Slicebox.scala
@@ -143,7 +143,10 @@ trait SliceboxBase extends SliceboxRoutes with DicomStreamOps with JsonFormats w
   val boxService: ActorRef = system.actorOf(BoxServiceActor.props(boxDao, apiBaseURL, storage), name = "BoxService")
   val scpService: ActorRef = system.actorOf(ScpServiceActor.props(scpDao, storage), name = "ScpService")
   val scuService: ActorRef = system.actorOf(ScuServiceActor.props(scuDao, storage), name = "ScuService")
-  val directoryService: ActorRef = system.actorOf(DirectoryWatchServiceActor.props(directoryWatchDao, storage), name = "DirectoryService")
+  val directoryService: ActorRef = {
+    val deleteWatchedDirectory: Boolean = sliceboxConfig.getBoolean("directory.delete-on-import")
+    system.actorOf(DirectoryWatchServiceActor.props(directoryWatchDao, storage, deleteWatchedDirectory), name = "DirectoryService")
+  }
   val seriesTypeService: ActorRef = system.actorOf(SeriesTypeServiceActor.props(seriesTypeDao, storage), name = "SeriesTypeService")
   val forwardingService: ActorRef = system.actorOf(ForwardingServiceActor.props(forwardingDao, storage), name = "ForwardingService")
   val importService: ActorRef = system.actorOf(ImportServiceActor.props(importDao), name = "ImportService")

--- a/src/main/scala/se/nimsa/sbx/app/Slicebox.scala
+++ b/src/main/scala/se/nimsa/sbx/app/Slicebox.scala
@@ -144,7 +144,7 @@ trait SliceboxBase extends SliceboxRoutes with DicomStreamOps with JsonFormats w
   val scpService: ActorRef = system.actorOf(ScpServiceActor.props(scpDao, storage), name = "ScpService")
   val scuService: ActorRef = system.actorOf(ScuServiceActor.props(scuDao, storage), name = "ScuService")
   val directoryService: ActorRef = {
-    val deleteWatchedDirectory: Boolean = sliceboxConfig.getBoolean("directory.delete-on-import")
+    val deleteWatchedDirectory: Boolean = sliceboxConfig.getBoolean("directory-watch.delete-on-import")
     system.actorOf(DirectoryWatchServiceActor.props(directoryWatchDao, storage, deleteWatchedDirectory), name = "DirectoryService")
   }
   val seriesTypeService: ActorRef = system.actorOf(SeriesTypeServiceActor.props(seriesTypeDao, storage), name = "SeriesTypeService")


### PR DESCRIPTION
slicebox will delete files from watched directories upon successful import.
The behavior is configurable through the directory.delete-on-import in the conf.